### PR TITLE
bash arrays

### DIFF
--- a/lib/Outthentic/Glue/Bash.pm
+++ b/lib/Outthentic/Glue/Bash.pm
@@ -24,9 +24,17 @@ sub json_var {
     $conf = $conf->{$n};    
   }
 
-  print $conf;
-
+  if ( $conf =~ "ARRAY") {
+    my $array_json = JSON->new;
+    my $array_conf = $array_json->encode($conf);
+    $array_conf =~ tr/[/(/;
+    $array_conf =~ tr/]/)/;
+    $array_conf =~ tr/\,/ /;
+    print $array_conf;
+  } else {
+    print $conf;
+  }
 }
 
-1;
 
+1;

--- a/lib/Outthentic/Glue/Bash.pm
+++ b/lib/Outthentic/Glue/Bash.pm
@@ -24,17 +24,13 @@ sub json_var {
     $conf = $conf->{$n};    
   }
 
-  if ( $conf =~ "ARRAY") {
-    my $array_json = JSON->new;
-    my $array_conf = $array_json->encode($conf);
-    $array_conf =~ tr/[/(/;
-    $array_conf =~ tr/]/)/;
-    $array_conf =~ tr/\,/ /;
-    print $array_conf;
+  if ( ref  $conf eq "ARRAY") { 
+    my $conf =  join ' ', @$conf ;
+    print '(' . $conf . ')';
   } else {
     print $conf;
   }
-}
 
+}
 
 1;


### PR DESCRIPTION
Здравствуйте. Насчет [массивов в bash](https://groups.google.com/forum/#!topic/sparrowhub/4YY181vbF2Q). Я не нашел способа вытаскивать целиком весь массив из функции config. Единственное, что смог придумать - сделать изменения в модуле MOutthentic::Glue::Bash, чтобы в случае массива строка превращалась в что-то  похожее на bash массивы. Это же модуль нигде больше не используется?

Сам bash не знает ничего о типах, поэтому единственный способ получить из функции config точно массив - использовать `decrare -a`. Есть и другие способы инициаллизации массива (https://www.opennet.ru/docs/RUS/bash_scripting_guide/c12790.html), но они у меня не сработали. Это надо указать будет, наверно. 

Можете попробовать на этом плагине - https://github.com/Spigell/my_animals. Просто запустите `strun` в корне.
