### PR TITLE
allow use helpers in libraries

### DIFF
--- a/bash_lib/outthentic.bash
+++ b/bash_lib/outthentic.bash
@@ -1,11 +1,3 @@
-if test -f "${story_dir}/common.bash"; then
-  source "${story_dir}/common.bash"
-fi
-
-if test -f "${project_root_dir}/common.bash"; then
-  source "${project_root_dir}/common.bash"
-fi
-
 if test -f "${cache_dir}/variables.bash"; then
   source "${cache_dir}/variables.bash"
 fi
@@ -50,3 +42,10 @@ function story_var {
    perl -MOutthentic::Glue::Bash -e json_var "${cache_dir}/variables.json" $1
 }
 
+if test -f "${story_dir}/common.bash"; then
+  source "${story_dir}/common.bash"
+fi
+
+if test -f "${project_root_dir}/common.bash"; then
+  source "${project_root_dir}/common.bash"
+fi


### PR DESCRIPTION
Здравствуйте. Перенес source файлов библиотек в самый низ. Таким образом можно использовать тот же config() в common.bash
Сломать ничего не должно. 